### PR TITLE
feat(db): criação da tabela de usuários e inserção automática de perfis

### DIFF
--- a/app/src/main/java/com/example/pi3/MainActivity.kt
+++ b/app/src/main/java/com/example/pi3/MainActivity.kt
@@ -1,11 +1,10 @@
 package com.example.pi3
 
-
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.widget.Button
-import android.widget.TextView
+import android.widget.EditText
 import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
@@ -14,6 +13,8 @@ import androidx.core.view.WindowInsetsCompat
 import com.example.pi3.apoio.ApoioActivity
 import com.example.pi3.coordenador.CoordenadorActivity
 import com.example.pi3.gestor.Gestor
+import com.example.pi3.data.UserRepository
+
 
 class MainActivity : AppCompatActivity() {
 
@@ -22,40 +23,36 @@ class MainActivity : AppCompatActivity() {
         enableEdgeToEdge()
         setContentView(R.layout.activity_main)
 
-        // Lógica de padding para a tela
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
             insets
         }
 
-        // Botão de login
         val btLogin: Button = findViewById(R.id.entrar_btn)
         btLogin.setOnClickListener(onClickLogin())
     }
 
     private fun onClickLogin(): View.OnClickListener {
-        return View.OnClickListener { v ->
-            val tLogin: TextView = findViewById(R.id.login_input)
-            val tSenha: TextView = findViewById(R.id.senha_input)
-            val login = tLogin.text.toString()
-            val senha = tSenha.text.toString()
+        return View.OnClickListener {
+            val tLogin: EditText = findViewById(R.id.login_input)
+            val tSenha: EditText = findViewById(R.id.senha_input)
+            val login = tLogin.text.toString().trim()
+            val senha = tSenha.text.toString().trim()
 
-            // Verificação simples de login e senha
-            if (login == "apoio" && senha == "123") {
-                // Navega para a tela do Apoio
-                val intent = Intent(this@MainActivity, ApoioActivity::class.java)
-                startActivity(intent)
-            } else if (login == "coordenador" && senha == "123") {
-                // Navega para a tela do Coordenador
-                val intent = Intent(this@MainActivity, CoordenadorActivity::class.java)
-                startActivity(intent)
-            } else if (login == "gestor" && senha == "123") {
-                // Navega para a tela do Gestor
-                val intent = Intent(this@MainActivity, Gestor::class.java)
-                startActivity(intent)
-            } else {
-                alert("Login e senha incorretos.")
+            if (login.isEmpty() || senha.isEmpty()) {
+                alert("Por favor, preencha todos os campos.")
+                return@OnClickListener
+            }
+
+            val userRepository = UserRepository(this)
+            val papel = userRepository.loginUsers(login, senha)
+
+            when (papel) {
+                "apoio" -> startActivity(Intent(this, ApoioActivity::class.java))
+                "coordenador" -> startActivity(Intent(this, CoordenadorActivity::class.java))
+                "gestor" -> startActivity(Intent(this, Gestor::class.java))
+                else -> alert("Login e/ou senha incorretos.")
             }
         }
     }

--- a/app/src/main/java/com/example/pi3/data/DBHelper.kt
+++ b/app/src/main/java/com/example/pi3/data/DBHelper.kt
@@ -23,7 +23,7 @@ class DBHelper(context: Context) : SQLiteOpenHelper(
         """
         db.execSQL(CREATE_ACTIONS_TABLE)
 
-        val CREATE_activities_TABLE = """
+        val CREATE_ACTIVITIES_TABLE = """
             CREATE TABLE ${TableActivities.TABLE_NAME} (
                 ${TableActivities.COLUMN_ID} INTEGER PRIMARY KEY AUTOINCREMENT,
                 ${TableActivities.COLUMN_TITULO} TEXT,
@@ -38,12 +38,32 @@ class DBHelper(context: Context) : SQLiteOpenHelper(
                 FOREIGN KEY(${TableActivities.COLUMN_ACAO_ID}) REFERENCES ${TableActions.TABLE_NAME}(${TableActions.COLUMN_ID})
             )
         """
-        db.execSQL(CREATE_activities_TABLE)
+        db.execSQL(CREATE_ACTIVITIES_TABLE)
+
+        // Criação da tabela de usuários
+        val CREATE_USERS_TABLE = """
+            CREATE TABLE ${TableUsers.TABLE_NAME} (
+                ${TableUsers.COLUMN_ID} INTEGER PRIMARY KEY AUTOINCREMENT,
+                ${TableUsers.COLUMN_PAPEL} TEXT,
+                ${TableUsers.COLUMN_SENHA} TEXT
+            )
+        """
+        db.execSQL(CREATE_USERS_TABLE)
+
+        // Inserção automática dos 3 papéis com senha padrão '123'
+        val INSERT_DEFAULT_USERS = """
+            INSERT INTO ${TableUsers.TABLE_NAME} (${TableUsers.COLUMN_PAPEL}, ${TableUsers.COLUMN_SENHA}) VALUES
+            ('apoio', '123'),
+            ('coordenador', '123'),
+            ('gestor', '123')
+        """
+        db.execSQL(INSERT_DEFAULT_USERS)
     }
 
     override fun onUpgrade(db: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
         db.execSQL("DROP TABLE IF EXISTS ${TableActivities.TABLE_NAME}")
         db.execSQL("DROP TABLE IF EXISTS ${TableActions.TABLE_NAME}")
+        db.execSQL("DROP TABLE IF EXISTS ${TableUsers.TABLE_NAME}")
         onCreate(db)
     }
 }

--- a/app/src/main/java/com/example/pi3/data/TableUsers.kt
+++ b/app/src/main/java/com/example/pi3/data/TableUsers.kt
@@ -1,0 +1,8 @@
+package com.example.pi3.data
+
+object TableUsers {
+    const val TABLE_NAME = "usuario"
+    const val COLUMN_ID = "id"
+    const val COLUMN_PAPEL = "papel" // 'apoio', 'coordenador' ou 'gestor'
+    const val COLUMN_SENHA = "senha"
+}

--- a/app/src/main/java/com/example/pi3/data/UserRepository.kt
+++ b/app/src/main/java/com/example/pi3/data/UserRepository.kt
@@ -1,0 +1,66 @@
+package com.example.pi3.data
+
+import android.content.ContentValues
+import android.content.Context
+import android.database.Cursor
+import com.example.pi3.model.UserRole
+
+class UserRepository(context: Context) {
+    private val dbHelper = DBHelper(context)
+
+    fun loginUsers(papel: String, senha: String): String? {
+        val db = dbHelper.readableDatabase
+        val cursor = db.rawQuery(
+            "SELECT ${TableUsers.COLUMN_PAPEL} FROM ${TableUsers.TABLE_NAME} WHERE ${TableUsers.COLUMN_PAPEL} = ? AND ${TableUsers.COLUMN_SENHA} = ?",
+            arrayOf(papel, senha)
+        )
+
+        var papelEncontrado: String? = null
+        if (cursor.moveToFirst()) {
+            papelEncontrado = cursor.getString(0) // Retorna "apoio", "coordenador" ou "gestor"
+        }
+        cursor.close()
+        return papelEncontrado
+    }
+
+    fun insertUsers(role: UserRole): Long {
+        val db = dbHelper.writableDatabase
+        val cv = ContentValues().apply {
+            put(TableUsers.COLUMN_PAPEL, role.name.lowercase())
+            put(TableUsers.COLUMN_SENHA, role.senhaPadrao)
+        }
+        return db.insert(TableUsers.TABLE_NAME, null, cv)
+    }
+
+    fun listUsers(): List<UserRole> {
+        val db = dbHelper.readableDatabase
+        val cursor: Cursor = db.query(
+            TableUsers.TABLE_NAME,
+            arrayOf(TableUsers.COLUMN_PAPEL),
+            null,
+            null,
+            null,
+            null,
+            null
+        )
+
+        val list = mutableListOf<UserRole>()
+        while (cursor.moveToNext()) {
+            val papelStr = cursor.getString(cursor.getColumnIndexOrThrow(TableUsers.COLUMN_PAPEL))
+            try {
+                val role = UserRole.fromString(papelStr)
+                list.add(role)
+            } catch (e: IllegalArgumentException) {
+                // Ignora papéis inválidos no banco
+            }
+        }
+        cursor.close()
+        return list
+    }
+
+    fun deleteAllUsers(): Int {
+        val db = dbHelper.writableDatabase
+        return db.delete(TableUsers.TABLE_NAME, null, null)
+    }
+}
+

--- a/app/src/main/java/com/example/pi3/model/UserRole.kt
+++ b/app/src/main/java/com/example/pi3/model/UserRole.kt
@@ -1,0 +1,18 @@
+package com.example.pi3.model
+
+enum class UserRole(val senhaPadrao: String) {
+    APOIO("123"),
+    COORDENADOR("123"),
+    GESTOR("123");
+
+    companion object {
+        fun fromString(value: String): UserRole {
+            return when (value.lowercase()) {
+                "apoio" -> APOIO
+                "coordenador" -> COORDENADOR
+                "gestor" -> GESTOR
+                else -> throw IllegalArgumentException("Papel inválido: $value")
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Criada a tabela "usuario" no banco SQLite com campos: id, papel e senha.
- Inserção automática dos perfis "apoio", "coordenador" e "gestor" com senha padrão "123".
- Implementada enumeração `UserRole` para padronizar os papéis e senhas.
- Criado `UserRepository` com funções para login, inserção, listagem e remoção de usuários.
- Adicionado controle de login na `MainActivity` com redirecionamento baseado no papel do usuário.