### PR TITLE
Fix: corrige filtro de responsável no histórico para incluir ações e atividades

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,14 +4,6 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-03-30T23:55:51.349945100Z">
-          <Target type="DEFAULT_BOOT">
-            <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\filip\.android\avd\Pixel_8_Pro.avd" />
-            </handle>
-          </Target>
-        </DropdownSelection>
-        <DialogSelection />
       </SelectionState>
     </selectionStates>
   </component>

--- a/app/src/main/java/com/example/pi3/gestor/HistoricoActivity.kt
+++ b/app/src/main/java/com/example/pi3/gestor/HistoricoActivity.kt
@@ -101,7 +101,12 @@ class HistoricoActivity : AppCompatActivity(), HistoricoAdapter.OnItemClickListe
 
     private fun loadAllItems() {
         val selectedResponsavel = spinnerFilterResponsavel.selectedItem?.toString() ?: "Todos"
-        val allActions = actionRepository.getAllActions()
+        val allActions = when (selectedResponsavel) {
+            "Todos" -> actionRepository.getAllActions()
+            "Apoio" -> actionRepository.getAllActions().filter { it.responsavel.equals("apoio", ignoreCase = true) }
+            "Coordenador" -> actionRepository.getAllActions().filter { it.responsavel.equals("coordenador", ignoreCase = true) }
+            else -> actionRepository.getAllActions()
+        }
         val allActivities = when (selectedResponsavel) {
             "Todos" -> activitieRepository.getAllApprovedActivities()
             "Apoio" -> activitieRepository.getApprovedActivitiesByResponsavel("apoio")
@@ -135,8 +140,20 @@ class HistoricoActivity : AppCompatActivity(), HistoricoAdapter.OnItemClickListe
 
             val responsavelMatch = when (selectedResponsavel) {
                 "Todos" -> true
-                "Apoio" -> if (item is Activitie) item.responsavel.equals("apoio", ignoreCase = true) else false
-                "Coordenador" -> if (item is Activitie) item.responsavel.equals("coordenador", ignoreCase = true) else false
+                "Apoio" -> {
+                    when (item) {
+                        is Activitie -> item.responsavel.equals("apoio", ignoreCase = true)
+                        is Action -> item.responsavel.equals("apoio", ignoreCase = true)
+                        else -> false
+                    }
+                }
+                "Coordenador" -> {
+                    when (item) {
+                        is Activitie -> item.responsavel.equals("coordenador", ignoreCase = true)
+                        is Action -> item.responsavel.equals("coordenador", ignoreCase = true)
+                        else -> false
+                    }
+                }
                 else -> false
             }
 


### PR DESCRIPTION
Pra resolver tive que ir na função filterItems, modifiquei a lógica do filtro de responsável para considerar tanto ações quanto atividades, antes tava pegando só atividades. Eu não tinha notado.
Também adicionei verificações específicas para cada tipo de item (Action e Activitie) pra ter certeza que o double filter ta bom.
E pra confirmar tudo, na função loadAllItems, eu botei a filtragem de ações com base no responsável selecionado, direto do database.